### PR TITLE
Add raw lossless attribute in messages

### DIFF
--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -334,6 +334,13 @@ impl<T: Attribute> LosslessAttribute<T> {
         }
     }
 
+    pub fn from_raw(inner: RawAttribute) -> Self {
+        LosslessAttribute::Unknown {
+            inner,
+            padding: None,
+        }
+    }
+
     pub fn as_known(&self) -> Option<&T> {
         match self {
             LosslessAttribute::Known { inner, .. } => Some(inner),

--- a/src/message.rs
+++ b/src/message.rs
@@ -216,6 +216,11 @@ impl<A: Attribute> Message<A> {
     pub fn add_attribute(&mut self, attribute: A) {
         self.attributes.push(LosslessAttribute::new(attribute));
     }
+
+    /// Adds the given raw attribute to the tail of the attributes in the message.
+    pub fn add_raw_attribute(&mut self, attribute: RawAttribute) {
+        self.attributes.push(LosslessAttribute::from_raw(attribute));
+    }
 }
 
 /// STUN message of which [`MessageDecoder`] could not decode the attribute part.


### PR DESCRIPTION
i would like to add in nat-detection library the ability to add additional custom attributes in addition to the attributes needed for nat detection. Reason: To support private stun servers use some sort of authentication before responding to requests.

In order to achieve that, first a support to add RawAttributes is needed on the codec side.